### PR TITLE
Add block_type to block_storage module

### DIFF
--- a/plugins/modules/block_storage.py
+++ b/plugins/modules/block_storage.py
@@ -33,6 +33,12 @@ options:
       - If it is larger than the volume's current size, the volume will be resized.
     aliases: [ size ]
     type: int
+  block_type:
+    description:
+      - An optional parameter, that determines on the type of block storage volume that will be created. Soon to become a required parameter.
+    default: high_perf
+    choices: [ high_perf, storage_opt ]
+    type: str
   region:
     description:
       - Region the block storage volume is deployed into.
@@ -63,6 +69,7 @@ EXAMPLES = """
   vultr.cloud.block_storage:
     name: myvolume
     size_gb: 10
+    block_type: storage_opt
     region: ams
 
 - name: Ensure a block storage volume is absent
@@ -75,12 +82,14 @@ EXAMPLES = """
     name: myvolume
     attached_to_instance: cb676a46-66fd-4dfb-b839-443f2e6c0b60
     size_gb: 50
+    block_type: high_perf
 
 - name: Ensure a block storage volume exists but is not attached to any server instance
   vultr.cloud.block_storage:
     name: myvolume
     attached_to_instance: ""
     size_gb: 50
+    block_type: high_perf
 """
 
 RETURN = """
@@ -219,6 +228,7 @@ def main():
             label=dict(type="str", required=True, aliases=["name"]),
             size_gb=dict(type="int", aliases=["size"]),
             region=dict(type="str"),
+            block_type=dict(type="str"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             attached_to_instance=dict(type="str"),
             live=dict(type="bool", default=False),
@@ -229,7 +239,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["size_gb", "region"]],
+            ["state", "present", ["size_gb", "region", "block_type"]],
         ],
     )
 
@@ -238,7 +248,7 @@ def main():
         namespace="vultr_block_storage",
         resource_path="/blocks",
         ressource_result_key_singular="block",
-        resource_create_param_keys=["label", "size_gb", "region"],
+        resource_create_param_keys=["label", "size_gb", "region", "block_type"],
         resource_update_param_keys=["size_gb"],
         resource_key_name="label",
     )

--- a/plugins/modules/block_storage.py
+++ b/plugins/modules/block_storage.py
@@ -228,7 +228,7 @@ def main():
             label=dict(type="str", required=True, aliases=["name"]),
             size_gb=dict(type="int", aliases=["size"]),
             region=dict(type="str"),
-            block_type=dict(type="str", required=True, choices=["high_perf", "storage_opt"], default="high_perf"),
+            block_type=dict(type="str", choices=["high_perf", "storage_opt"], default="high_perf"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             attached_to_instance=dict(type="str"),
             live=dict(type="bool", default=False),

--- a/plugins/modules/block_storage.py
+++ b/plugins/modules/block_storage.py
@@ -164,6 +164,11 @@ vultr_block_storage:
       returned: success
       type: int
       sample: 50
+    block_type:
+      description: HDD or NVMe (storage_opt or high_perf)
+      returned: success
+      type: str
+      sample: high_perf
     status:
       description: Status about the deployment of the volume.
       returned: success

--- a/plugins/modules/block_storage.py
+++ b/plugins/modules/block_storage.py
@@ -227,7 +227,7 @@ def main():
         dict(
             label=dict(type="str", required=True, aliases=["name"]),
             size_gb=dict(type="int", aliases=["size"]),
-            block_type=dict(type="str", choices=["high_perf", "storage_opt"], default="high_perf"),
+            block_type=dict(type="str"),
             region=dict(type="str"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             attached_to_instance=dict(type="str"),
@@ -239,7 +239,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["size_gb", "region", "block_type"]],
+            ["state", "present", ["size_gb", "region"]],
         ],
     )
 

--- a/plugins/modules/block_storage.py
+++ b/plugins/modules/block_storage.py
@@ -227,8 +227,8 @@ def main():
         dict(
             label=dict(type="str", required=True, aliases=["name"]),
             size_gb=dict(type="int", aliases=["size"]),
-            region=dict(type="str"),
             block_type=dict(type="str", choices=["high_perf", "storage_opt"], default="high_perf"),
+            region=dict(type="str"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             attached_to_instance=dict(type="str"),
             live=dict(type="bool", default=False),

--- a/plugins/modules/block_storage.py
+++ b/plugins/modules/block_storage.py
@@ -228,7 +228,7 @@ def main():
             label=dict(type="str", required=True, aliases=["name"]),
             size_gb=dict(type="int", aliases=["size"]),
             region=dict(type="str"),
-            block_type=dict(type="str"),
+            block_type=dict(type="str", required=True, choices=["high_perf", "storage_opt"], default="high_perf"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             attached_to_instance=dict(type="str"),
             live=dict(type="bool", default=False),

--- a/plugins/modules/block_storage_info.py
+++ b/plugins/modules/block_storage_info.py
@@ -100,6 +100,11 @@ vultr_block_storage_info:
       returned: success
       type: int
       sample: 50
+    block_type:
+      description: Block type, either NVMe (high_perf) or HDD (storage_opt)
+      returned: success
+      type: str
+      sample: high_perf
     status:
       description: Status about the deployment of the volume.
       returned: success

--- a/tests/integration/targets/block_storage/defaults/main.yml
+++ b/tests/integration/targets/block_storage/defaults/main.yml
@@ -6,6 +6,8 @@ vultr_block_storage_size_3: 14
 
 vultr_block_storage_region: ewr
 
+vultr_block_storage_block_type: high_perf
+
 vultr_instance_name: "{{ vultr_resource_prefix }}_vm_for_attachment"
 vultr_instance_ssh_keys:
   - name: "{{ vultr_resource_prefix }}_key1"

--- a/tests/integration/targets/block_storage/tasks/tests.yml
+++ b/tests/integration/targets/block_storage/tasks/tests.yml
@@ -10,6 +10,7 @@
   vultr.cloud.block_storage:
     name: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
   check_mode: true
@@ -22,6 +23,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
 - name: verify test create block storage volume
@@ -36,6 +38,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
 - name: verify test create block storage volume idempotence
@@ -50,6 +53,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size - 1 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
 - name: verify test shrink block storage ignored
@@ -69,6 +73,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
   check_mode: true
@@ -82,6 +87,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
 - name: verify test resize block storage volume
@@ -94,6 +100,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
 - name: verify test resize block storage volume idempotency
@@ -110,6 +117,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
   register: result
 - name: verify test shrinking warning block storage volume

--- a/tests/integration/targets/block_storage/tasks/tests_attach_to_server.yml
+++ b/tests/integration/targets/block_storage/tasks/tests_attach_to_server.yml
@@ -25,6 +25,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: ""
   register: result
@@ -41,6 +42,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: "{{ result_server_setup.vultr_instance.id }}"
   register: result
@@ -55,6 +57,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: "{{ result_server_setup.vultr_instance.id }}"
   register: result
@@ -71,6 +74,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: "{{ result_server_setup.vultr_instance.id }}"
   register: result
@@ -89,6 +93,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: "{{ result_server_setup.vultr_instance.id }}"
   register: result
@@ -106,6 +111,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: ""
   register: result
@@ -120,6 +126,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: ""
   register: result
@@ -133,6 +140,7 @@
   vultr.cloud.block_storage:
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size_2 }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
     region: "{{ vultr_block_storage_region }}"
     attached_to_instance: ""
   register: result

--- a/tests/integration/targets/block_storage_info/defaults/main.yml
+++ b/tests/integration/targets/block_storage_info/defaults/main.yml
@@ -3,3 +3,5 @@ vultr_resource_prefix: "vultr-test-prefix"
 vultr_block_storage_name: "{{ vultr_resource_prefix }}-volume"
 vultr_block_storage_size: 10
 vultr_block_storage_region: ewr
+
+vultr_block_storage_block_type: high_perf

--- a/tests/integration/targets/block_storage_info/tasks/tests.yml
+++ b/tests/integration/targets/block_storage_info/tasks/tests.yml
@@ -9,6 +9,7 @@
     label: "{{ vultr_block_storage_name }}"
     size_gb: "{{ vultr_block_storage_size }}"
     region: "{{ vultr_block_storage_region }}"
+    block_type: "{{ vultr_block_storage_block_type }}"
 
 - name: test gather vultr block storage volume info in check mode
   vultr.cloud.block_storage_info:


### PR DESCRIPTION

## Description
Enables block_type param for vultr.cloud.block_storage which is an upcoming requirement as mentioned here-- https://www.vultr.com/api/#operation/create-block

## Related Issues
fixes #25 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
