### PR TITLE
fix: wrong attribute name in example

### DIFF
--- a/plugins/modules/region_info.py
+++ b/plugins/modules/region_info.py
@@ -31,7 +31,7 @@ EXAMPLES = """
 
 - name: Print the gathered information
   ansible.builtin.debug:
-    var: result.region_info
+    var: result.vultr_region_info
 """
 
 RETURN = """


### PR DESCRIPTION
## Description
Example of region_info has a spelling error `result.region_info` should be `result.vultr_region_info`

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
