### PR TITLE
vultr: Use correct syntax for unit test workflow

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -56,8 +56,6 @@ jobs:
           --docker
           -v
           --color
-          --continue-on-error
-          --diff
           --python ${{ matrix.python }}
           --coverage
 


### PR DESCRIPTION
Erroneous arguments to `ansible-test units` command in unit test workflow.