### PR TITLE
inventory: add v6_main_ip to attributes

### DIFF
--- a/changelogs/fragments/inventory-ipv6.yml
+++ b/changelogs/fragments/inventory-ipv6.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory - Added IPv6 support by adding ``v6_main_ip`` to the attributes and improved docs (https://github.com/vultr/ansible-collection-vultr/pull/54).

--- a/plugins/inventory/vultr.py
+++ b/plugins/inventory/vultr.py
@@ -75,6 +75,7 @@ options:
       - plan
       - hostname
       - main_ip
+      - v6_main_ip
   filters:
     description:
       - Filter hosts with Jinja2 templates.
@@ -125,6 +126,11 @@ filters:
 plugin: vultr.cloud.vultr
 compose:
   ansible_host: vultr_main_ip
+
+# Respectively for IPv6:
+plugin: vultr.cloud.vultr
+compose:
+  ansible_host: vultr_v6_main_ip
 """
 
 RETURN = r""" # """

--- a/plugins/inventory/vultr.py
+++ b/plugins/inventory/vultr.py
@@ -131,6 +131,11 @@ compose:
 plugin: vultr.cloud.vultr
 compose:
   ansible_host: vultr_v6_main_ip
+
+# Prioritize IPv6 over IPv4 if available.
+plugin: vultr.cloud.vultr
+compose:
+  ansible_host: vultr_v6_main_ip or vultr_main_ip
 """
 
 RETURN = r""" # """


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
there might be ipv6 only instances in vultr, so we should probably support IPv6.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

## Manual tests

create instance with ipv6

```
vultr-cli instance create --region=ams --plan=vc2-1c-1gb --os=477 --label test4 --ipv6 --ssh-keys 00b6a84f-79cb-43f5-8700-e6a4ba12b9e4
```

see (redacted ) instance info:
```
 $ vultr-cli instance get b85dee2b-a933-409c-a7ff-5e22edca90bc
INSTANCE INFO
ID			b85dee2b-a933-409c-a7ff-5e22edca90bc
Os			Debian 11 x64 (bullseye)
RAM			1024
DISK			25
MAIN IP			95.179.153.130
VCPU COUNT		1
REGION			ams
DATE CREATED		2023-01-15T10:11:34-05:00
STATUS			active
NETMASK V4		255.255.254.0
GATEWAY V4		95.179.152.1
POWER STATUS		running
SERVER STATE		installingbooting
PLAN			vc2-1c-1gb
LABEL			test4
TAG			
OsID			477
FIREWALL GROUP ID	5b6c06fb-4c4a-40cd-9910-39fa1fc45260
V6 MAIN IP		2a05:f480:1400:00a9:5400:04ff:fe46:5f38
V6 NETWORK		2a05:f480:1400:a9::
V6 NETWORK SIZE		64
FEATURES		[ipv6]
```

dynamic vultr inventory setting:

```yaml
# file: test.vultr.yml
plugin: vultr.cloud.vultr
compose:
  ansible_host: vultr_v6_main_ip
```

enabling vultr.cloud.vultr inventory
```ini
# file: ansible.cfg                                
[inventory]
enable_plugins = vultr.cloud.vultr
```

other settings for settings
```
export  ANSIBLE_HOST_KEY_CHECKING=False
export ANSIBLE_COLLECTIONS_PATH=<path/to>/ansible_collections
```

smoke test
```
 $ ansible-inventory -i test.vultr.yml --list     
{
    "_meta": {
        "hostvars": {
            "test4": {
                "ansible_host": "2a05:f480:1400:00a9:5400:04ff:fe46:5f38",
                "vultr_hostname": "vultr.guest",
                "vultr_id": "b85dee2b-a933-409c-a7ff-5e22edca90bc",
                "vultr_label": "test4",
                "vultr_main_ip": "95.179.153.130",
                "vultr_plan": "vc2-1c-1gb",
                "vultr_region": "ams",
                "vultr_v6_main_ip": "2a05:f480:1400:00a9:5400:04ff:fe46:5f38"
            }
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "test4"
        ]
    }
}
```

ping by ssh
```
$ ansible -m ping -i test.vultr.yml test4 -u root
test4 | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "ping": "pong"
}
```