### PR TITLE
Fix typo with file endings in example

### DIFF
--- a/plugins/inventory/vultr.py
+++ b/plugins/inventory/vultr.py
@@ -116,7 +116,7 @@ notes:
 
 EXAMPLES = """
 ---
-# File endings vultr{,-{hosts,instances}}.y{,a}ml
+# File endings vultr{,_{hosts,instances}}.y{,a}ml
 # All configuration done via environment variables:
 plugin: vultr.cloud.vultr
 


### PR DESCRIPTION
Example provided in documentation didn't match the validity checks embedded in vultr.py inventory plugin.

## Description
Update example filenames to match in-code validity checks

running ansible-inventory with -vvv shows
```
host_list declined parsing /[path]/vultr-instances.yaml as it did not pass its verify_file() method
Skipping due to inventory configuration file name mismatch. Valid filename endings: vultr.yaml, vultr.yml, vultr_hosts.yaml, vultr_hosts.yml, vultr_instances.yaml, vultr_instances.yml
```


### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

