### PR TITLE
firewall_rule: ignore port if not tcp/udp but warn

### DIFF
--- a/changelogs/fragments/firewall_rule-fix-idempotency-icmp.yml
+++ b/changelogs/fragments/firewall_rule-fix-idempotency-icmp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - firewall_rule - Fixed an idempotency issue if parameter ``port`` is set on protocols other than TCP/UDP (https://github.com/vultr/ansible-collection-vultr/issues/76).

--- a/plugins/modules/firewall_rule.py
+++ b/plugins/modules/firewall_rule.py
@@ -212,6 +212,21 @@ class AnsibleVultrFirewallRule(AnsibleVultr):
         if source is not None and source != "cloudflare":
             self.module.params["source"] = self.get_load_balancer()["id"]
 
+        # Warn about port only affects TCP and UDP protocol
+        if (
+            self.module.params.get("protocol")
+            not in (
+                "tcp",
+                "udp",
+            )
+            and self.module.params.get("port") is not None
+        ):
+            self.module.warn(
+                "Setting a port (%s) only affects protocols TCP/UDP, but protocol is: %s. Ignoring."
+                % (self.module.params.get("port"), self.module.params.get("protocol"))
+            )
+            self.module.params["port"] = None
+
     def query(self):
         result = dict()
         for resource in self.query_list():

--- a/tests/integration/targets/firewall_rule/defaults/main.yml
+++ b/tests/integration/targets/firewall_rule/defaults/main.yml
@@ -35,6 +35,7 @@ vultr_firewall_rules:
     subnet_size: 0
     # Port should be ignored, but should show a warning
     port: "7"
+    port_assert: ""
 
   - notes: web app
     port: "8000:8080"

--- a/tests/integration/targets/firewall_rule/defaults/main.yml
+++ b/tests/integration/targets/firewall_rule/defaults/main.yml
@@ -33,6 +33,8 @@ vultr_firewall_rules:
     protocol: icmp
     subnet: "0.0.0.0"
     subnet_size: 0
+    # Port should be ignored, but should show a warning
+    port: "7"
 
   - notes: web app
     port: "8000:8080"

--- a/tests/integration/targets/firewall_rule/tasks/rule_absent.yml
+++ b/tests/integration/targets/firewall_rule/tasks/rule_absent.yml
@@ -20,7 +20,7 @@
       - result is changed
       - result.vultr_firewall_rule.action == "accept"
       - result.vultr_firewall_rule.protocol == "{{ rule.protocol | default('tcp') }}"
-      - result.vultr_firewall_rule.port == "{{ rule.port | default('') }}"
+      - result.vultr_firewall_rule.port == "{{ rule.port_assert | default(rule.port | default('')) }}"
       - result.vultr_firewall_rule.subnet == "{{ rule.subnet | default('') }}"
       - result.vultr_firewall_rule.subnet_size == {{ rule.subnet_size | default(0) }}
       - result.vultr_firewall_rule.ip_type == "{{ rule.ip_type | default('v4') }}"
@@ -41,7 +41,7 @@
       - result is changed
       - result.vultr_firewall_rule.action == "accept"
       - result.vultr_firewall_rule.protocol == "{{ rule.protocol | default('tcp') }}"
-      - result.vultr_firewall_rule.port == "{{ rule.port | default('') }}"
+      - result.vultr_firewall_rule.port == "{{ rule.port_assert | default(rule.port | default('')) }}"
       - result.vultr_firewall_rule.subnet == "{{ rule.subnet | default('') }}"
       - result.vultr_firewall_rule.subnet_size == {{ rule.subnet_size | default(0) }}
       - result.vultr_firewall_rule.ip_type == "{{ rule.ip_type | default('v4') }}"

--- a/tests/integration/targets/firewall_rule/tasks/rule_present.yml
+++ b/tests/integration/targets/firewall_rule/tasks/rule_present.yml
@@ -35,7 +35,7 @@
       - result is changed
       - result.vultr_firewall_rule.action == "accept"
       - result.vultr_firewall_rule.protocol == "{{ rule.protocol | default('tcp') }}"
-      - result.vultr_firewall_rule.port == "{{ rule.port | default('') }}"
+      - result.vultr_firewall_rule.port == "{{ rule.port_assert | default(rule.port | default('')) }}"
       - result.vultr_firewall_rule.subnet == "{{ rule.subnet | default('') }}"
       - result.vultr_firewall_rule.subnet_size == {{ rule.subnet_size | default(0) }}
       - result.vultr_firewall_rule.ip_type == "{{ rule.ip_type | default('v4') }}"
@@ -56,7 +56,7 @@
       - result is not changed
       - result.vultr_firewall_rule.action == "accept"
       - result.vultr_firewall_rule.protocol == "{{ rule.protocol | default('tcp') }}"
-      - result.vultr_firewall_rule.port == "{{ rule.port | default('') }}"
+      - result.vultr_firewall_rule.port == "{{ rule.port_assert | default(rule.port | default('')) }}"
       - result.vultr_firewall_rule.subnet == "{{ rule.subnet | default('') }}"
       - result.vultr_firewall_rule.subnet_size == {{ rule.subnet_size | default(0) }}
       - result.vultr_firewall_rule.ip_type == "{{ rule.ip_type | default('v4') }}"


### PR DESCRIPTION
## Description
Fix idempotency if port is set but protocol is not tcp/udp. Also see https://www.vultr.com/api/#operation/post-firewalls-firewall-group-id-rules

## Related Issues
Fixes #76 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
