### PR TITLE
fix wait for state to be more strict

### DIFF
--- a/plugins/module_utils/vultr_v2.py
+++ b/plugins/module_utils/vultr_v2.py
@@ -259,18 +259,18 @@ class AnsibleVultr:
     def wait_for_state(self, resource, key, states, cmp="=", retries=60):
         for retry in range(0, retries):
             resource = self.query_by_id(resource_id=resource[self.resource_key_id], skip_transform=False)
-            if cmp == "=":
-                if key not in resource or resource[key] in states or not resource[key]:
+            if resource and key in resource:
+                if cmp == "=" and resource[key] in states:
                     break
-            else:
-                if key not in resource or resource[key] not in states or not resource[key]:
+                elif resource[key] not in states:
                     break
             backoff(retry=retry)
         else:
             if cmp == "=":
-                self.module.fail_json(msg="Wait for %s to become %s timed out" % (key, states))
+                msg = "Wait for %s to become one in %s timed out" % (key, states)
             else:
-                self.module.fail_json(msg="Wait for %s to not be in %s timed out" % (key, states))
+                msg = "Wait for %s to not be in %s timed out" % (key, states)
+            self.module.fail_json(msg=msg)
 
         return resource
 


### PR DESCRIPTION
We see a failing integration tests while trying to delete an instance. The code should have waited for a `server_state` not in "locked", "none" but did not, this is unexpected.

## Description
a task before we got:

```
"server_status": "none"
```

after we got:

```
fatal: [testhost]: FAILED! => {"changed": false, "fetch_url_info": {"body": "{\"error\":\"Unable to destroy server: Unable to remove VM: Server is currently locked\",\"status\":500}", "connection": "close", "content-type": "application/json", "date": "Tue, 26 Sep 2023 04:15:10 GMT", "msg": "HTTP Error 500: Internal Server Error", "server": "nginx", "status": 500, "strict-transport-security": "max-age=63072000", "transfer-encoding": "chunked", "url": "https://api.vultr.com/v2/instances/8ba702b8-ddf2-4e18-9e0f-c288f3c66569", "x-content-type-options": "nosniff", "x-frame-options": "DENY", "x-robots-tag": "noindex,noarchive", "x-user": "ansible+opensource@vultr.com"}, "msg": "Failure while calling the Vultr API v2 with DELETE for \"/instances/8ba702b8-ddf2-4e18-9e0f-c288f3c66569\"."}
```

so I assume the api returned `locked` but if we had one of these states, why is the code not waiting? was the key not returned? resource was not queries? 

That is why I refactored the code a bit to be more strict for these cases and also wait 

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
