### PR TITLE
fix reserved_ip not tested

### DIFF
--- a/changelogs/fragments/reserved_ip-fix-broken-module.yml
+++ b/changelogs/fragments/reserved_ip-fix-broken-module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reserved_ip - Fixed an issue which caused the module to fail, also enabled integration tests (https://github.com/vultr/ansible-collection-vultr/issues/92).

--- a/plugins/modules/reserved_ip.py
+++ b/plugins/modules/reserved_ip.py
@@ -166,7 +166,6 @@ class AnsibleVultrReservedIp(AnsibleVultr):
 
         instance_name = self.module.params["instance_name"]
         if instance_name is not None:
-
             # Empty string ID means detach instance
             if len(instance_name) == 0:
                 return ""
@@ -187,7 +186,7 @@ class AnsibleVultrReservedIp(AnsibleVultr):
 
             return resources["instances"][0]["id"]
 
-    def query_list(self, path=None, result_key=None):
+    def query_list(self, path=None, result_key=None, query_params=None):
         resources = self.api_query(path=self.resource_path) or dict()
 
         resources_filtered = list()

--- a/tests/integration/targets/reserved_ip/aliases
+++ b/tests/integration/targets/reserved_ip/aliases
@@ -1,0 +1,3 @@
+cloud/vultr
+needs/target/common
+needs/target/cleanup

--- a/tests/integration/targets/reserved_ip/defaults/main.yml
+++ b/tests/integration/targets/reserved_ip/defaults/main.yml
@@ -1,9 +1,11 @@
 # Copyright (c) 2021, René Moser <mail@renemoser.net>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-vultr_reserved_ip_name: "{{ vultr_resource_prefix }}-ip"
+vultr_reserved_ip_name: "{{ vultr_resource_prefix }}_reserved_ip"
+vultr_reserved_ip_region: ams
 
-# TODO: topic of changes
-vultr_server_name: "{{ vultr_resource_prefix }}_vm"
-vultr_server_os: CentOS 7 x64
-vultr_server_plan: 1024 MB RAM,25 GB SSD,1.00 TB BW
+vultr_instance:
+  label: "{{ vultr_resource_prefix }}_reserved_ip"
+  plan: vc2-1c-1gb
+  region: "{{ vultr_reserved_ip_region }}"
+  os: Debian 12 x64 (bookworm)

--- a/tests/integration/targets/reserved_ip/tasks/tests.yml
+++ b/tests/integration/targets/reserved_ip/tasks/tests.yml
@@ -5,7 +5,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     state: absent
   register: result
 - name: verify setup
@@ -23,20 +23,18 @@
       - result is failed
       - 'result.msg == "missing required arguments: ip_type, label, region"'
 
-# TODO: topic of changes
-- name: setup create the server
-  ngine_io.vultr.vultr_server:
-    name: "{{ vultr_server_name }}"
-    os: "{{ vultr_server_os }}"
-    plan: "{{ vultr_server_plan }}"
-    region: New Jersey
-  register: server
+- name: setup instance
+  vultr.cloud.instance:
+    label: "{{ vultr_instance.label }}"
+    os: "{{ vultr_instance.os }}"
+    plan: "{{ vultr_instance.plan }}"
+    region: "{{ vultr_instance.region }}"
 
 - name: test create reserved ip in check mode
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
   register: result
   check_mode: true
 - name: verify test create reserved ip in check mode
@@ -48,7 +46,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
   register: result
 - name: verify test create reserved ip
   ansible.builtin.assert:
@@ -63,7 +61,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
   register: result
 - name: verify test create reserved ip idempotence
   ansible.builtin.assert:
@@ -78,8 +76,8 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
-    instance_name: "{{ vultr_server_name }}"
+    region: "{{ vultr_reserved_ip_region }}"
+    instance_name: "{{ vultr_instance.label }}"
   register: result
   check_mode: true
 - name: verify test detach instance of reserved ip in check mode
@@ -95,8 +93,8 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
-    instance_name: "{{ vultr_server_name }}"
+    region: "{{ vultr_reserved_ip_region }}"
+    instance_name: "{{ vultr_instance.label }}"
   register: result
 - name: verify test attach instance of reserved ip
   ansible.builtin.assert:
@@ -111,8 +109,8 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
-    instance_name: "{{ vultr_server_name }}"
+    region: "{{ vultr_reserved_ip_region }}"
+    instance_name: "{{ vultr_instance.label }}"
   register: result
 - name: verify test attach instance of reserved ip idempotence
   ansible.builtin.assert:
@@ -127,7 +125,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
   register: result
 - name: verify test test ignore instance attached reserved ip idempotence
   ansible.builtin.assert:
@@ -142,7 +140,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     instance_id: ""
   register: result
   check_mode: true
@@ -159,7 +157,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     instance_id: ""
   register: result
 - name: verify test detach instance of reserved ip
@@ -175,7 +173,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     instance_id: ""
   register: result
 - name: verify test detach instance of reserved ip idempotence
@@ -191,7 +189,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     state: absent
   register: result
   check_mode: true
@@ -208,7 +206,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     state: absent
   register: result
 - name: verify test absent reserved ip
@@ -225,7 +223,7 @@
   vultr.cloud.reserved_ip:
     label: "{{ vultr_reserved_ip_name }}"
     ip_type: v4
-    region: ewr
+    region: "{{ vultr_reserved_ip_region }}"
     state: absent
   register: result
 - name: verify test absent reserved ip idempotence
@@ -233,8 +231,8 @@
     that:
       - result is not changed
 
-# TODO: topic of changes
-- name: cleanup the server
-  ngine_io.vultr.vultr_server:
-    name: "{{ vultr_server_name }}"
+- name: cleanup instance
+  vultr.cloud.instance:
+    label: "{{ vultr_instance.label }}"
+    region: "{{ vultr_instance.region }}"
     state: absent


### PR DESCRIPTION
## Description
When the `ip_reserved` module was created, the `instance` module was not ready yet. That is why test were disabled and forgotten to enable them, when `instance` module became available. 

Due to the lack of testing a change in the method `query_list` was missed to adjust in the `ip_reserved` module which broke the module.

## Related Issues
fixes #92

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
