### PR TITLE
implement distinguish per region if available

### DIFF
--- a/changelogs/fragments/distinguish-per-region.yml
+++ b/changelogs/fragments/distinguish-per-region.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Implemented a feature to distinguish resources by region if available.
+    This allows to have identical name per region e.g. a VPC named ``default`` in each region. (https://github.com/vultr/ansible-collection-vultr/pull/98).

--- a/plugins/module_utils/common_instance.py
+++ b/plugins/module_utils/common_instance.py
@@ -22,7 +22,7 @@ class AnsibleVultrCommonInstance(AnsibleVultr):
             "param": "vpc2s",
             "path": "/vpc2",
             "suffix": "2",
-        }
+        },
     }
 
     def get_ssh_key_ids(self):
@@ -61,6 +61,9 @@ class AnsibleVultrCommonInstance(AnsibleVultr):
 
         vpc_ids = list()
         for vpc in vpcs:
+            if self.module.params["region"] != vpc["region"]:
+                continue
+
             if vpc["description"] in vpc_names:
                 vpc_ids.append(vpc["id"])
                 vpc_names.remove(vpc["description"])

--- a/tests/integration/targets/instance/defaults/main.yml
+++ b/tests/integration/targets/instance/defaults/main.yml
@@ -7,6 +7,10 @@ vultr_instance_ssh_key: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAgEAyWYItY+3w5b8PdGRoz0
 
 vutr_instance_vpcs:
   - description: "{{ vultr_resource_prefix }}_instance_vpc_1"
+    v4_subnet: 192.168.24.0
+    v4_subnet_mask: 24
+    region: ewr
+  - description: "{{ vultr_resource_prefix }}_instance_vpc_1"
     v4_subnet: 192.168.42.0
     v4_subnet_mask: 24
     region: ams

--- a/tests/integration/targets/vpc/defaults/main.yml
+++ b/tests/integration/targets/vpc/defaults/main.yml
@@ -3,3 +3,4 @@ vultr_vpc_description: "{{ vultr_resource_prefix }}_vpc"
 vultr_vpc_v4_subnet: 192.168.42.0
 vultr_vpc_v4_subnet_mask: 24
 vultr_vpc_region: ewr
+vultr_vpc_region_2: ams

--- a/tests/integration/targets/vpc/tasks/tests.yml
+++ b/tests/integration/targets/vpc/tasks/tests.yml
@@ -72,9 +72,38 @@
       - result.vultr_vpc.v4_subnet == vultr_vpc_v4_subnet
       - result.vultr_vpc.v4_subnet_mask == vultr_vpc_v4_subnet_mask
 
+- name: test create vpc in diff region but same description
+  vultr.cloud.vpc:
+    description: "{{ vultr_vpc_description }}"
+    v4_subnet: "{{ vultr_vpc_v4_subnet }}"
+    v4_subnet_mask: "{{ vultr_vpc_v4_subnet_mask }}"
+    region: "{{ vultr_vpc_region_2 }}"
+  register: result
+- name: verify test create vpc in diff region but same description
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result.vultr_vpc.description == vultr_vpc_description
+      - result.vultr_vpc.region == vultr_vpc_region_2
+      - result.vultr_vpc.v4_subnet == vultr_vpc_v4_subnet
+      - result.vultr_vpc.v4_subnet_mask == vultr_vpc_v4_subnet_mask
+
+- name: test destroy vpc having 2 vpcs with same description distinqush region
+  vultr.cloud.vpc:
+    description: "{{ vultr_vpc_description }}"
+    state: absent
+  register: result
+  ignore_errors: true
+  check_mode: true
+- name: verify test destroy vpc having 2 vpcs with same description distinqush region
+  ansible.builtin.assert:
+    that:
+      - result is failed
+
 - name: test destroy vpc in check mode
   vultr.cloud.vpc:
     description: "{{ vultr_vpc_description }}"
+    region: "{{ vultr_vpc_region }}"
     state: absent
   register: result
   check_mode: true
@@ -90,6 +119,7 @@
 - name: test destroy vpc
   vultr.cloud.vpc:
     description: "{{ vultr_vpc_description }}"
+    region: "{{ vultr_vpc_region }}"
     state: absent
   register: result
 - name: verify test destroy vpc
@@ -104,9 +134,21 @@
 - name: test destroy an existing vpc idempotence
   vultr.cloud.vpc:
     description: "{{ vultr_vpc_description }}"
+    region: "{{ vultr_vpc_region }}"
     state: absent
   register: result
 - name: verify test destroy an existing vpc idempotence
   ansible.builtin.assert:
     that:
       - result is not changed
+
+- name: cleanup vpc in diff region
+  vultr.cloud.vpc:
+    description: "{{ vultr_vpc_description }}"
+    region: "{{ vultr_vpc_region_2 }}"
+    state: absent
+  register: result
+- name: verify test cleanup vpc in diff region
+  ansible.builtin.assert:
+    that:
+      - result is changed


### PR DESCRIPTION
## Description
Some resources such as VPC must be distinguished per region. But the modules managing resources having a region did not take it into account.

With this change we now also use the region to distinguish the resource. This allows to have identical name per region e.g. a VPC named `prod` or `default` in each region.

/cc @timdiggins

## Related Issues

also see #94 (ff)

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
