### PR TITLE
retry on gateway timeout

### DIFF
--- a/changelogs/fragments/104- retry-on-gateway-timeout.yml
+++ b/changelogs/fragments/104- retry-on-gateway-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added retry on HTTP 504 returned by the API (https://github.com/vultr/ansible-collection-vultr/pull/104).

--- a/plugins/module_utils/vultr_v2.py
+++ b/plugins/module_utils/vultr_v2.py
@@ -164,7 +164,8 @@ class AnsibleVultr:
             # Check for:
             # 429 Too Many Requests
             # 500 Internal Server Error
-            if info["status"] not in (429, 500):
+            # 504 Gateway Time-out
+            if info["status"] not in (429, 500, 504):
                 break
 
             # Vultr has a rate limiting requests per second, try to be polite


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Add retry on gateway timeout:

```
TASK [instance : test reinstall instance] **************************************
fatal: [testhost]: FAILED! => {"changed": false, "fetch_url_info": {"body": "We are currently conducting some software upgrades.  Check back in a few minutes!\n", "connection": "close", "content-length": "82", "content-type": "text/html; charset=utf-8", "date": "Sun, 17 Dec 2023 16:30:04 GMT", "etag": "\"635ad729-52\"", "msg": "HTTP Error 504: Gateway Time-out", "server": "nginx", "status": 504, "strict-transport-security": "max-age=63072000", "url": "https://api.vultr.com/v2/instances/72c898c5-1c85-4d02-8294-bbbaca5b6d94/reinstall", "x-content-type-options": "nosniff", "x-frame-options": "DENY", "x-robots-tag": "noindex,noarchive"}, "msg": "Failure while calling the Vultr API v2 with POST for \"/instances/72c898c5-1c85-4d02-8294-bbbaca5b6d94/reinstall\"."}
```

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
