### PR TITLE
fix name-label alias bug in instance_info module

### DIFF
--- a/plugins/modules/instance_info.py
+++ b/plugins/modules/instance_info.py
@@ -239,8 +239,8 @@ def main():
     argument_spec = vultr_argument_spec()
     argument_spec.update(
         dict(
-            region=dict(type="str", aliases=["name"]),
-            label=dict(type="str"),
+            region=dict(type="str"),
+            label=dict(type="str", aliases=["name"]),
         )  # type: ignore
     )
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
fixes the bug where the name attribute refers to region instead of label

## Related Issues
Fixes #105 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
