### PR TITLE
fix: prevent key error on id if API returns empty response

### DIFF
--- a/plugins/module_utils/vultr_v2.py
+++ b/plugins/module_utils/vultr_v2.py
@@ -271,8 +271,9 @@ class AnsibleVultr:
         return resources[result_key] if resources else []
 
     def wait_for_state(self, resource, key, states, cmp="=", retries=60):
+        resource_id = resource[self.resource_key_id]
         for retry in range(0, retries):
-            resource = self.query_by_id(resource_id=resource[self.resource_key_id], skip_transform=False)
+            resource = self.query_by_id(resource_id=resource_id, skip_transform=False)
             if resource and key in resource:
                 if cmp == "=":
                     if resource[key] in states:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
prevent key error on id if API returns empty response in wait_for_state

## Related Issues
#108 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
