### PR TITLE
Update vpc.py example to use v4_

### DIFF
--- a/plugins/modules/vpc.py
+++ b/plugins/modules/vpc.py
@@ -53,8 +53,8 @@ EXAMPLES = """
 - name: Ensure a VPC is present
   vultr.cloud.vpc:
     description: my VPC.
-    subnet: 10.99.1.0
-    subnet_mask: 24
+    v4_subnet: 10.99.1.0
+    v4_subnet_mask: 24
     region: ewr
 
 - name: Ensure a VPC is absent


### PR DESCRIPTION
## Description
The VPC examples use `subnet` and `subnet_mask` but the correct usage is `v4_subnet` and `v4_subnet_mask`


### Checklist:

* [✓] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [✓] Have you linted your code locally prior to submission?
* [✓] Have you successfully ran tests with your changes locally?
