### PR TITLE
Issue #135 - Specify object storage tier level

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the `vultr.cloud` Ansible Collection . The collection w
 ---
 **NOTE**
 
-`vultr.cloud` is the successor of deprecated `ngine_io.vultr` collection which used the sunsetted Vultr v1 API.
+`vultr.cloud` is the successor of deprecated `ngine_io.vultr` collection which used the sunset Vultr v1 API.
 
 ---
 

--- a/plugins/modules/instance.py
+++ b/plugins/modules/instance.py
@@ -470,7 +470,7 @@ class AnsibleVultrInstance(AnsibleVultrCommonInstance):
                     skip_wait=self.module.params.get("skip_wait", False),
                 )
 
-            # Hanlde power status
+            # Handle power status
             resource = self.handle_power_status(
                 resource=resource,
                 state="stopped",

--- a/tests/integration/targets/object_storage/defaults/main.yml
+++ b/tests/integration/targets/object_storage/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 vultr_object_storage_name: "{{ vultr_resource_prefix }}-object-storage"
+vultr_object_storage_tier: Standard
 vultr_object_storage_cluster1: del1.vultrobjects.com
 vultr_object_storage_cluster2: ams1.vultrobjects.com

--- a/tests/integration/targets/object_storage/tasks/tests.yml
+++ b/tests/integration/targets/object_storage/tasks/tests.yml
@@ -5,6 +5,7 @@
   vultr.cloud.object_storage:
     label: "{{ vultr_object_storage_name }}"
     cluster: "{{ vultr_object_storage_cluster1 }}"
+    tier: "{{ vultr_object_storage_tier }}"
   register: result
   check_mode: true
 - name: verify test create object storage in check mode
@@ -16,6 +17,7 @@
   vultr.cloud.object_storage:
     label: "{{ vultr_object_storage_name }}"
     cluster: "{{ vultr_object_storage_cluster1 }}"
+    tier: "{{ vultr_object_storage_tier }}"
   register: result
 - name: verify test create object storage
   ansible.builtin.assert:
@@ -28,6 +30,7 @@
   vultr.cloud.object_storage:
     label: "{{ vultr_object_storage_name }}"
     cluster: "{{ vultr_object_storage_cluster2 }}"
+    tier: "{{ vultr_object_storage_tier }}"
   register: result
 - name: verify test create object storage
   ansible.builtin.assert:
@@ -40,6 +43,7 @@
   vultr.cloud.object_storage:
     label: "{{ vultr_object_storage_name }}"
     cluster: "{{ vultr_object_storage_cluster1 }}"
+    tier: "{{ vultr_object_storage_tier }}"
   register: result
 - name: verify test create object storage idempotence
   ansible.builtin.assert:


### PR DESCRIPTION
## Description
Allows specifying the now required storage tier for Object Storage subscriptions

A follow-up feature issue will add the _info modules for getting tier information

## Related Issues
Fixes #135 
Related to #131 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
