### PR TITLE
Next round of Integration Test Fixes

### DIFF
--- a/tests/integration/targets/cleanup/tasks/cleanup_bare_metal.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_bare_metal.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List bare metals
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_block_storage.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_block_storage.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List blocks
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_dns_domain.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_dns_domain.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List dns domains
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_firewall_group.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_firewall_group.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List firewall groups
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_instance.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_instance.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List instances
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_load_balancer.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_load_balancer.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List load balancers
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_network.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_network.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List networks
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_object_storage.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_object_storage.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List object storages
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_reserved_ip.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_reserved_ip.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List reserved-ips
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_snapshot.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_snapshot.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List snapshots
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_ssh_key.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_ssh_key.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List ssh-keys
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_startup_script.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_startup_script.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List startup-scripts
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_user.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_user.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List users
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_vpc.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_vpc.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List vpcs
       ansible.builtin.uri:

--- a/tests/integration/targets/cleanup/tasks/cleanup_vpc2.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_vpc2.yml
@@ -1,6 +1,6 @@
 ---
 - name: cleanup
-  when: vultr_api_key
+  when: vultr_api_key is defined and vultr_api_key != ''
   block:
     - name: List vpc2s
       ansible.builtin.uri:

--- a/tests/integration/targets/object_storage_info/defaults/main.yml
+++ b/tests/integration/targets/object_storage_info/defaults/main.yml
@@ -2,5 +2,7 @@
 vultr_object_storage_info_stores:
   - label: "{{ vultr_resource_prefix }}-object-storage-info1"
     cluster: sjc1.vultrobjects.com
+    tier: Standard
   - label: "{{ vultr_resource_prefix }}-object-storage-info2"
     cluster: sgp1.vultrobjects.com
+    tier: Standard

--- a/tests/integration/targets/object_storage_info/tasks/tests.yml
+++ b/tests/integration/targets/object_storage_info/tasks/tests.yml
@@ -3,6 +3,7 @@
   vultr.cloud.object_storage:
     label: "{{ obj.label }}"
     cluster: "{{ obj.cluster }}"
+    tier: "{{ obj.tier }}"
   register: create_result
   with_items: "{{ vultr_object_storage_info_stores }}"
   loop_control:

--- a/tests/integration/targets/user/tasks/tests.yml
+++ b/tests/integration/targets/user/tasks/tests.yml
@@ -80,7 +80,7 @@
     that:
       - result is changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'john.doe{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - result.vultr_user.api_enabled == true
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
@@ -101,7 +101,7 @@
     that:
       - result is not changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'john.doe{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - result.vultr_user.api_enabled == true
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
@@ -110,7 +110,7 @@
 - name: test update user in check mode
   vultr.cloud.user:
     name: "{{ vultr_user_name }}"
-    email: jimmy{{ vultr_resource_prefix }}@example.com
+    email: john.doe{{ vultr_resource_prefix }}@example.com
     password: "z,!B.DpCe.P6/8(pO||z"
     api_enabled: false
     acls:
@@ -124,7 +124,7 @@
     that:
       - result is changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'john.doe{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
       - "'dns' in result.vultr_user.acls"
@@ -133,7 +133,7 @@
 - name: test update user
   vultr.cloud.user:
     name: "{{ vultr_user_name }}"
-    email: jimmy{{ vultr_resource_prefix }}@example.com
+    email: john.doe{{ vultr_resource_prefix }}@example.com
     password: "z,!B.DpCe.P6/8(pO||z"
     api_enabled: false
     acls:
@@ -146,7 +146,7 @@
     that:
       - result is changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'jimmy{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
       - "'support' in result.vultr_user.acls"
@@ -155,7 +155,7 @@
 - name: test update user idempotence
   vultr.cloud.user:
     name: "{{ vultr_user_name }}"
-    email: jimmy{{ vultr_resource_prefix }}@example.com
+    email: john.doe{{ vultr_resource_prefix }}@example.com
     password: "z,!B.DpCe.P6/8(pO||z"
     api_enabled: false
     acls:
@@ -168,7 +168,7 @@
     that:
       - result is not changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'jimmy{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
       - "'support' in result.vultr_user.acls"
@@ -185,7 +185,7 @@
     that:
       - result is changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'jimmy{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
       - "'support' in result.vultr_user.acls"
@@ -201,7 +201,7 @@
     that:
       - result is changed
       - result.vultr_user.name == vultr_user_name
-      - result.vultr_user.email == 'jimmy{{ vultr_resource_prefix }}@example.com'
+      - result.vultr_user.email == 'john.doe' ~ vultr_resource_prefix ~ '@example.com'
       - "'upgrade' in result.vultr_user.acls"
       - "'manage_users' in result.vultr_user.acls"
       - "'support' in result.vultr_user.acls"


### PR DESCRIPTION
## Description
- Fix string comparison as bool in cleanup tasks for ansible-2.19
- Define storage tier for object_storage_info module test
- Update user test to no longer attempt updating a field that cannot be updated via API
- Remove some double interpolation assertion checks for user test

## Related Issues
Related to #131
Related to #139 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
