### PR TITLE
Fix: Convert base64-encoded user_data to string for JSON serialization

### DIFF
--- a/plugins/module_utils/common_instance.py
+++ b/plugins/module_utils/common_instance.py
@@ -189,7 +189,7 @@ class AnsibleVultrCommonInstance(AnsibleVultr):
                 self.module.params["image_id"] = self.get_image()["image_id"]
 
             if self.module.params.get("user_data") is not None:
-                self.module.params["user_data"] = base64.b64encode(self.module.params["user_data"].encode())
+                self.module.params["user_data"] = base64.b64encode(self.module.params["user_data"].encode()).decode('utf-8')
 
             if self.module.params.get("ssh_keys") is not None:
                 # sshkey_id ist a list of ids


### PR DESCRIPTION
Fixes #156

The user_data parameter was causing a JSON serialization error because base64.b64encode() returns bytes, not a string. This caused the error: 'Object of type bytes is not JSON serializable by the tagless profile.'

This fix adds .decode('utf-8') to convert the bytes object to a string that can be properly JSON serialized when making API calls.

Fixes instances and bare_metal modules that use user_data parameter.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
