### PR TITLE
tests: ignore errors on cleanup tasks

### DIFF
--- a/tests/integration/targets/cleanup/tasks/cleanup_all.yml
+++ b/tests/integration/targets/cleanup/tasks/cleanup_all.yml
@@ -5,15 +5,28 @@
     msg: Cleaning up resources with prefix {{ vultr_resource_prefix }}
 
 - ansible.builtin.import_tasks: cleanup_instance.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_bare_metal.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_ssh_key.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_vpc.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_vpc2.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_firewall_group.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_snapshot.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_user.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_dns_domain.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_block_storage.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_startup_script.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_reserved_ip.yml
+  ignore_errors: true
 - ansible.builtin.import_tasks: cleanup_network.yml
+  ignore_errors: true


### PR DESCRIPTION
## Description
don't stop cleaning in case of an error in cleaning up resources

## Related Issues
CI run fails

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
