### PR TITLE
Add support for UEFI snapshots

### DIFF
--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -30,6 +30,12 @@ options:
       - Mutually exclusive with I(url).
       - I(instance) or I(url) is required if I(state=present).
     type: str
+  uefi:
+    description:
+      - Whether or not the snapshot uses UEFI.
+      - Only considered on creation when I(url) is provided.
+    type: bool
+    default: false
   url:
     description:
       - The URL of the snapshot image (RAW) to be uploaded.
@@ -164,6 +170,8 @@ class AnsibleVultrSnapshot(AnsibleVultr):
 
         if self.module.params.get("url") is not None:
             self.resource_create_param_keys.append("url")
+            if self.module.params.get("uefi") is not None:
+                self.resource_create_param_keys.append("uefi")
             # Upload by URL has a different endpoint
             self.resource_path = self.resource_path + "/create-from-url"
         else:
@@ -187,6 +195,7 @@ def main():
         dict(
             description=dict(type="str", required=True, aliases=["name"]),
             instance=dict(type="str"),
+            uefi=dict(type="bool", default=False),
             url=dict(type="str"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
         )  # type: ignore

--- a/tests/integration/targets/snapshot/defaults/main.yml
+++ b/tests/integration/targets/snapshot/defaults/main.yml
@@ -13,3 +13,7 @@ vultr_snapshots:
 
   - description: "{{ vultr_resource_prefix }}_desc2"
     url: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.raw
+
+  - description: "{{ vultr_resource_prefix }}_desc3"
+    url: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.raw
+    uefi: true

--- a/tests/integration/targets/snapshot/tasks/present.yml
+++ b/tests/integration/targets/snapshot/tasks/present.yml
@@ -15,6 +15,7 @@
   vultr.cloud.snapshot:
     description: "{{ snapshot.description }}"
     instance: "{{ snapshot.instance | default(omit) }}"
+    uefi: "{{ snapshot.uefi | default(omit) }}"
     url: "{{ snapshot.url | default(omit) }}"
   register: result
 - name: verify test create snapshot


### PR DESCRIPTION
The UEFI state is not returned in api responses.

Please assume I don't know how ansible modules work. I haven't actually run the
test suite, but uploading snapshots works fine with and without UEFI from a
playbook.