### PR TITLE
Updated documentation to use "map('lower')" instead of "lower".

### DIFF
--- a/plugins/inventory/vultr.py
+++ b/plugins/inventory/vultr.py
@@ -93,7 +93,7 @@ plugin: vultr.cloud.vultr
 plugin: vultr.cloud.vultr
 api_key: '{{ lookup("pipe"), "./get_vultr_api_key.sh" }}'
 keyed_groups:
-  - key: vultr_tags | lower
+  - key: vultr_tags | map('lower')
     prefix: ''
     separator: ''
 filters:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Updated documentation to reference "map('lower')" instead of "lower" for
```
keyed_groups:
  - key: vultr_tags | map('lower')
    prefix: ''
    separator: ''
```

## Related Issues
Addresses #169 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
