### PR TITLE
Set Content-Type: application/json for all API requests

### DIFF
--- a/plugins/module_utils/vultr_v2.py
+++ b/plugins/module_utils/vultr_v2.py
@@ -126,6 +126,7 @@ class AnsibleVultr:
 
         self.headers = {
             "Authorization": "Bearer %s" % self.module.params["api_key"],
+            "Content-Type": "application/json",
             "User-Agent": VULTR_USER_AGENT,
             "Accept": "application/json",
         }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Recent changes in Vultr's API made it necessary to explicitly specify the Content-Type header when making requests

## Related Issues
Fixes #186 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
